### PR TITLE
leo - WiFi: Add overlay configurations for bcmdhd

### DIFF
--- a/aosp_d6603.mk
+++ b/aosp_d6603.mk
@@ -20,6 +20,7 @@ $(call inherit-product, $(SRC_TARGET_DIR)/product/telephony.mk)
 $(call inherit-product-if-exists, device/sony/shinano/device.mk)
 $(call inherit-product-if-exists, vendor/sony/leo/leo-vendor.mk)
 $(call inherit-product, frameworks/native/build/phone-xhdpi-2048-dalvik-heap.mk)
+$(call inherit-product-if-exists, hardware/broadcom/wlan/bcmdhd/config/config-bcm.mk)
 #$(call inherit-product-if-exists, hardware/broadcom/wlan/bcmdhd/firmware/bcm4354/device-bcm.mk)
 
 PRODUCT_COPY_FILES += \


### PR DESCRIPTION
Those are needed for the new driver on 3.10