### PR TITLE
leo: add overrides to configure the HWUI memory limits

### DIFF
--- a/aosp_d6603.mk
+++ b/aosp_d6603.mk
@@ -66,6 +66,20 @@ PRODUCT_COPY_FILES += \
     device/sony/leo/rootdir/system/etc/tfa98xx/VoiceCallEarpice_top.preset:/system/etc/tfa98xx/VoiceCallEarpice_top.preset \
     device/sony/leo/rootdir/system/etc/tfa98xx/VoiceCallEarpice_top.eq:/system/etc/tfa98xx/VoiceCallEarpice_top.eq
 
+# Provides overrides to configure the HWUI memory limits
+PRODUCT_PROPERTY_OVERRIDES += \
+    ro.hwui.texture_cache_size=48 \
+    ro.hwui.layer_cache_size=32 \
+    ro.hwui.r_buffer_cache_size=4 \
+    ro.hwui.path_cache_size=24 \
+    ro.hwui.gradient_cache_size=1 \
+    ro.hwui.drop_shadow_cache_size=5 \
+    ro.hwui.texture_cache_flushrate=0.5 \
+    ro.hwui.text_small_cache_width=1024 \
+    ro.hwui.text_small_cache_height=1024 \
+    ro.hwui.text_large_cache_width=2048 \
+    ro.hwui.text_large_cache_height=1024
+
 PRODUCT_NAME := aosp_d6603
 PRODUCT_DEVICE := leo
 PRODUCT_MODEL := Xperia Z3 (AOSP)


### PR DESCRIPTION
reference:
https://github.com/omnirom/android_frameworks_native/blob/android-5.1/build/phone-xxhdpi-2048-hwui-memory.mk

AOSP properties:
https://android.googlesource.com/platform/frameworks/base/+/master/libs/hwui/Properties.h

Signed-off-by: Humberto Borba <humberos@gmail.com>