### PR TITLE
leo: Update dalvik.vm.heapgrowthlimit from 192M to 256M

### DIFF
--- a/aosp_d6603.mk
+++ b/aosp_d6603.mk
@@ -78,5 +78,6 @@ PRODUCT_AAPT_PREBUILT_DPI := xxhdpi xhdpi hdpi
 PRODUCT_AAPT_PREF_CONFIG := xxhdpi
 
 PRODUCT_PROPERTY_OVERRIDES += \
+    dalvik.vm.heapgrowthlimit=256m \
     ro.sf.lcd_density=480 \
     ro.usb.pid_suffix=1BA


### PR DESCRIPTION
this entry is present at
frameworks/native/build/phone-xhdpi-2048-dalvik-heap.mk
with 192M as default value

BUT

the new value (256M) is used on shamu device (also with 3GB of RAM - like leo devices)

Commit reference:
https://android.googlesource.com/device/moto/shamu/+/2e51cd2c599f826f8cb82b4a309f0eb89ff8f5ed

Signed-off-by: Humberto Borba <humberos@gmail.com>