### PR TITLE
[DO NOT MERGE]leo: solve max_brigthness on display

### DIFF
--- a/rootdir/system/etc/thermanager.xml
+++ b/rootdir/system/etc/thermanager.xml
@@ -29,7 +29,7 @@
 		</resource>
 
 		<!-- device-specific -->
-		<resource name="backlight" type="sysfs">/sys/class/leds/wled:backlight/max_brightness</resource>
+		<resource name="backlight" type="sysfs">/sys/class/leds/lcd-backlight/max_brightness</resource>
 
 		<resource name="temp-emmc" type="msm-adc">/sys/devices/00-vadc-3100/emmc_therm</resource>
 		<resource name="temp-batt" type="msm-adc">/sys/devices/00-vadc-3100/batt_therm</resource>


### PR DESCRIPTION
when the device come up from sleep the display brightness is set to max_brightness all the time

Signed-off-by: David Viteri <davidteri91@gmail.com>

@jerpelea only for get another dev's comments about this "issue" on my device