### PR TITLE
leo: Enable simple PowerHAL for native double-tap-to-wake

### DIFF
--- a/BoardConfig.mk
+++ b/BoardConfig.mk
@@ -22,3 +22,6 @@ BOARD_USERDATAIMAGE_PARTITION_SIZE := 12656242688
 #BOARD_KERNEL_CMDLINE += mem=1281M@255M mem=1409M@2048M
 
 PRODUCT_VENDOR_KERNEL_HEADERS += device/sony/leo/kernel-headers
+
+TARGET_TAP_TO_WAKE_NODE := "/sys/devices/virtual/input/clearpad/wakeup_gesture"
+TARGET_TAP_TO_WAKE_STRING := true


### PR DESCRIPTION
Signed-off-by: Adam Farden <adam@farden.cz>
Signed-off-by: David Viteri <davidteri91@gmail.com>

requires: https://github.com/sonyxperiadev/device-sony-shinano/pull/223